### PR TITLE
<fix> ensure _original_dir is always set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ python:
 install:
   - pip install -r requirements.txt
 before_script:
-  - wget -nv https://commondatastorage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.3.zip
-  - unzip -q google_appengine_1.9.3.zip
+  - wget -nv https://commondatastorage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.7.zip
+  - unzip -q google_appengine_1.9.7.zip
 script:
   - ./run_tests.py
 

--- a/nose2gae/__init__.py
+++ b/nose2gae/__init__.py
@@ -37,6 +37,7 @@ class Nose2GAE(events.Plugin):
         super(Nose2GAE, self).__init__(*args, **kwargs)
         self._config_loaded = False
         self._gae_testbed_inited = False
+        self._original_dir = None
 
     def _loadConfig(self):
         if self._config_loaded:


### PR DESCRIPTION
If setUpClass throws an exception, it's possible that testOutcome will be invoked before startTest; indeed, in this case startTest will not be invoked at all! This ensures that _original_dir is well-defined in this and other hook ordering cases.

_Update:_ Also fixed up Travis to bring the GAE dependency up to 1.9.7.
